### PR TITLE
fix: do not post a mesasge on exitcode=0

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -217,6 +217,9 @@ func (c *Controller) handlePod(pod *v1.Pod) error {
 		if status.RestartCount == 0 {
 			continue
 		}
+		if status.LastTerminationState.Terminated.ExitCode == 0 {
+			continue
+		}
 
 		klog.Infof("Handle: %s restarted! , restartCount: %d\n\n", podKey, status.RestartCount)
 


### PR DESCRIPTION
To vastly reduce the amount of messages that are not of any concern, skip sending messages if the exitcode equals 0.  For most applications, this means that we exited without any problems.

Resolve: airwallex/k8s-pod-restart-info-collector#22