### PR TITLE
feat: Add flag to ignore restart events with exit code 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2023-05-11
+### Added
+- Add `ignoreRestartsWithExitCodeZero` flag to ignore restart events with an exit code of 0 [#22](https://github.com/airwallex/k8s-pod-restart-info-collector/issues/22)
+
 ## [1.2.1] - 2023-04-27
 ### Fixed
 - Container resource specs showing wrong values [#26](https://github.com/airwallex/k8s-pod-restart-info-collector/issues/26)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ helm uninstall k8s-pod-restart-info-collector
 | `ignoreRestartCount`                | The number of pod restart count to ignore | default: `"30"`
 | `ignoredNamespaces`                 | A comma-separated list of namespaces to ignore | default: `""`    
 | `ignoredPodNamePrefixes`            | A comma-separated list of pod name prefixes to ignore | default: `""`   
+| `ignoreRestartsWithExitCodeZero`    | Whether restart events with an exit code of 0 should be ignored | default: `false`
 | `slackWebhookUrl`                   | Slack webhook URL | required if slackWebhooUrlSecretKeyRef is not present                       |
 | `slackWebhookurlSecretKeyRef.key`   | Slack webhook URL SecretKeyRef.key                 | |
 | `slackWebhookurlSecretKeyRef.name`  | Slack webhook URL SecretKeyRef.name                | |

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-TAG="v1.2.1"
+TAG="v1.3.0"
 docker buildx build --platform linux/amd64 -t devopsairwallex/k8s-pod-restart-info-collector:${TAG} .
 docker push devopsairwallex/k8s-pod-restart-info-collector:${TAG}
 

--- a/controller.go
+++ b/controller.go
@@ -218,7 +218,12 @@ func (c *Controller) handlePod(pod *v1.Pod) error {
 			continue
 		}
 
-		klog.Infof("Handle: %s restarted! , restartCount: %d\n\n", podKey, status.RestartCount)
+		if shouldIgnoreRestartsWithExitCodeZero(status) {
+			klog.Infof("Ignore: %s restarted with ExitCode 0, restartCount: %d\n", podKey, status.RestartCount)
+			continue
+		}
+
+		klog.Infof("Handle: %s restarted, restartCount: %d\n", podKey, status.RestartCount)
 
 		podInfo, err := printPod(pod)
 		if err != nil {

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: {{ .Values.ignoredNamespaces | quote}}
             - name: IGNORED_POD_NAME_PREFIXES
               value: {{ .Values.ignoredPodNamePrefixes | quote}}
+            - name: IGNORE_RESTARTS_WITH_EXIT_CODE_ZERO
+              value: {{ .Values.ignoreRestartsWithExitCodeZero | quote}}
             - name: SLACK_WEBHOOK_URL
               valueFrom:
               {{- include "k8s-pod-restart-info-collector.SlackWebhookUrlSecret" . | indent 14 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,9 +18,12 @@ ignoredNamespaces: ""
 # A comma-separated list of pod name prefixes to ignore
 ignoredPodNamePrefixes: ""
 
+# Whether restart events with an exit code of 0 should be ignored, true or false
+ignoreRestartsWithExitCodeZero: false
+
 image:
   repository: devopsairwallex/k8s-pod-restart-info-collector
-  tag: "v1.1.0"
+  tag: "v1.3.0"
 
 resources: 
   limits:

--- a/helpers.go
+++ b/helpers.go
@@ -57,6 +57,17 @@ func isIgnoredPod(name string) bool {
 	return false
 }
 
+func shouldIgnoreRestartsWithExitCodeZero(status v1.ContainerStatus) bool {
+	if os.Getenv("IGNORE_RESTARTS_WITH_EXIT_CODE_ZERO") != "true" {
+		return false
+	}
+
+	if status.LastTerminationState.Terminated != nil && status.LastTerminationState.Terminated.ExitCode == 0 {
+		return true
+	}
+	return false
+}
+
 func getIgnoreRestartCount() int {
 	ignoreRestartCount, err := strconv.Atoi(os.Getenv("IGNORE_RESTART_COUNT"))
 	if err != nil {


### PR DESCRIPTION
Close https://github.com/airwallex/k8s-pod-restart-info-collector/issues/22

Add `ignoreRestartsWithExitCodeZero` flag to ignore restart events with an exit code of 0