### PR TITLE
feat: Ignore specific errors for given pods

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -263,6 +263,11 @@ func (c *Controller) handlePod(pod *v1.Pod) error {
 		if err != nil {
 			return err
 		}
+
+		if isIgnoredErrorForPod(pod.Name, lastNonEmptyLogLine(containerLogs)) {
+			continue
+		}
+
 		if containerLogs == "" {
 			containerLogs = "• No Logs Before Restart\n"
 		} else {

--- a/controller.go
+++ b/controller.go
@@ -264,7 +264,7 @@ func (c *Controller) handlePod(pod *v1.Pod) error {
 			return err
 		}
 
-		if isIgnoredErrorForPod(pod.Name, lastNonEmptyLogLine(containerLogs)) {
+		if isIgnoredErrorForPod(pod.Name, containerLogs) {
 			continue
 		}
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               value: {{ .Values.watchedPodNamePrefixes | quote}}
             - name: IGNORED_POD_NAME_PREFIXES
               value: {{ .Values.ignoredPodNamePrefixes | quote}}
-            - name: IGNORED_ERROR_FOR_POD_NAME_PREFIXES
+            - name: IGNORED_ERRORS_FOR_POD_NAME_PREFIXES
               value: {{ .Values.ignoredErrorsForPodNamePrefixes | quote}}
             - name: IGNORE_RESTARTS_WITH_EXIT_CODE_ZERO
               value: {{ .Values.ignoreRestartsWithExitCodeZero | quote}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: {{ .Values.watchedPodNamePrefixes | quote}}
             - name: IGNORED_POD_NAME_PREFIXES
               value: {{ .Values.ignoredPodNamePrefixes | quote}}
+            - name: IGNORED_ERROR_FOR_POD_NAME_PREFIXES
+              value: {{ .Values.ignoredErrorsForPodNamePrefixes | quote}}
             - name: IGNORE_RESTARTS_WITH_EXIT_CODE_ZERO
               value: {{ .Values.ignoreRestartsWithExitCodeZero | quote}}
             - name: SLACK_WEBHOOK_URL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,6 +18,10 @@ ignoredNamespaces: ""
 # A comma-separated list of pod name prefixes to ignore
 ignoredPodNamePrefixes: ""
 
+# A json map with specific errors to ignore from specific pods
+# {"podName": ["error 1", "error 2"]}
+ignoredErrorsForPodNamePrefixes: ""
+
 # A comma-separated list of namespaces to watch, default is all ("")
 watchedNamespaces: ""
 # A comma-separated list of pod name prefixes to watch, default is all ("").

--- a/helpers.go
+++ b/helpers.go
@@ -88,19 +88,6 @@ func isIgnoredErrorForPod(podName string, errorLog string) bool {
 	return false
 }
 
-func lastNonEmptyLogLine(logs string) string {
-	logLines := strings.Split(logs, "\n")
-
-	for i := 1; i <= len(logLines); i++ {
-		lastLogLine := logLines[len(logLines)-i]
-		if lastLogLine != "" {
-			return lastLogLine;
-		}
-	}
-
-	return ""
-}
-
 func isWatchedNamespace(namespace string) bool {
 	watchedNamespacesEnv := os.Getenv("WATCHED_NAMESPACES")
 	if watchedNamespacesEnv == "" {


### PR DESCRIPTION
Add support for ignoring a specific restart error for a specific type of pod.
Example: We have a `gke-metrics-agent` that sometimes can't start because of ` Failed to run the service: failed to start extensions: listen tcp 127.0.0.1:8203: bind: address already in use`. With the current implementation we can ignore that by adding 
```
ignoredErrorsForPodNamePrefixes = "{ "gke-metrics-agent": [ "address already in use" ]}"
```